### PR TITLE
migrate config to v3 but leave old one in place just in case

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,8 +66,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "09.09.24:", desc: "Existing users should move: config_local.php to config/local.php - for COPS 3.x release" }
-  - { date: "01.09.24:", desc: "Existing users should verify: config_local.php - define $config['cops_kepubify_path'] if you want to use it" }
+  - { date: "09.09.24:", desc: "In COPS 3.x, the config_local.php is being moved over to config/local.php and this container will automatically migrate it. Existing users should verify: config_local.php and/or config/local.php - define $config['cops_kepubify_path'] if they want to use it" }
   - { date: "28.08.24:", desc: "Add kepubify tool to update metadata for Kobo - see mikespub-org/seblucas-cops#77" }
   - { date: "24.06.24:", desc: "Rebase to Alpine 3.20. Existing users should update their nginx confs to avoid http2 deprecation warnings." }
   - { date: "07.05.24:", desc: "Existing users should verify: site-confs/default.conf - Fix rewriting rules default site conf." }

--- a/root/etc/s6-overlay/s6-rc.d/init-cops-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-cops-config/run
@@ -23,7 +23,13 @@ done
 
 # copy config
 if [[ ! -e /config/config/local.php ]]; then
-    cp /defaults/config/local.php /config/config/local.php
+    if [[ -e /config/config_local.php ]]; then
+        echo "**** Existing config found, migrating for v3. Please check the contents of /config/config/local.php which will be the active config in v3 ****"
+        cp /config/config_local.php /config/config/local.php
+    else
+        echo "**** New instance detected, generating default config at /config/config/local.php ****"
+        cp /defaults/config/local.php /config/config/local.php
+    fi
 fi
 
 # copy extra user-profiles


### PR DESCRIPTION
This PR will do migration but will leave the old config in place, which will be active until upgrade to v3.

It will duplicate the confs (old and new) but won't break existing installs.